### PR TITLE
fix: don't fetch a single bsky profile 1000s of times

### DIFF
--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -6,3 +6,4 @@ PUBLIC_DEFAULT_SPACE_ID=
 PUBLIC_SHOW_BRANDING=
 PUBLIC_DISCORD_BRIDGE=http://localhost:3301
 VITE_LEAF_URL=http://localhost:5530/
+VITE_STREAM_NSID=space.roomy.stream.dev.local

--- a/packages/app/src/lib/workers/backendWorker.ts
+++ b/packages/app/src/lib/workers/backendWorker.ts
@@ -406,7 +406,7 @@ async function createOauthClient(): Promise<OAuthClient> {
   if (import.meta.env.DEV) {
     // Get the base URL and redirect URL for this deployment
     if (globalThis.location.hostname == "localhost")
-      globalThis.location.hostname = "127.0.0.1";
+      throw new Error("hostname must be 127.0.0.1 if local");
     const baseUrl = new URL(`http://127.0.0.1:${globalThis.location.port}`);
     baseUrl.hash = "";
     baseUrl.pathname = "/";
@@ -451,7 +451,8 @@ async function initializeLeafClient(client: LeafClient) {
     console.log("Leaf: authenticated as", did);
 
     if (!state.agent) throw new Error("ATProto agent not initialized");
-    const streamNsid = import.meta.env.VITE_STREAM_NSID || "space.roomy.stream.dev";
+    const streamNsid =
+      import.meta.env.VITE_STREAM_NSID || "space.roomy.stream.dev";
 
     // Get the user's personal space ID
     let streamId: string;

--- a/packages/app/src/lib/workers/db/ingestEvents.ts
+++ b/packages/app/src/lib/workers/db/ingestEvents.ts
@@ -1,6 +1,5 @@
-import type { CompPage } from "$lib/db/types/components";
-import type { EdgeLabel } from "$lib/db/types/edges";
-import type { EntityId, EntityLabel } from "$lib/db/types/entities";
+import type { EdgeLabel } from "./types/edges";
+import type { EntityId, EntityLabel } from "./types/entities";
 import { base32crockford } from "@scure/base";
 import type {
   AnyEvent,
@@ -27,7 +26,7 @@ import type {
   UploadStartEvent,
   UserCreateEvent,
   UserSubscribeThreadEvent,
-} from "../lib/db/types/events";
+} from "./types/events";
 import { executeQuery } from "./setup-sqlite";
 
 function encodeJsonToBlob(data: unknown): Uint8Array {


### PR DESCRIPTION
and a few other little things

main fix:

```
/** When mapping incoming events to SQL, 'ensureProfile' checks whether a DID
 * exists in the profiles table. If not, it makes an API call to bsky to get some
 * basic info, and then returns SQL to add it to the profiles table. Rather than
 * inserting it immediately and breaking transaction atomicity, this is just a set
 * of flags to indicate that the profile doesn't need to be re-fetched.
 */
let ensuredProfiles = new Set();
```